### PR TITLE
(security) update anymap

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -2,9 +2,9 @@ name: Rust Examples
 
 on:
   push:
-    branches: [ main ]
+    branches: [ "*" ]
   pull_request:
-    branches: [ main ]
+    branches: [ "*" ]
 
 env:
   CARGO_TERM_COLOR: always
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Build
       working-directory: examples
       run: cargo build
@@ -23,6 +23,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Rustfmt
       run: 'bash -c "find examples/ -not \( -path \"examples/target\" -prune \) -name \"*.rs\" | xargs rustfmt --check"'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,9 @@ name: RustCI
 
 on:
   push:
-    branches: [ main ]
+    branches: [ "*" ]
   pull_request:
-    branches: [ main ]
+    branches: [ "*" ]
 
 env:
   CARGO_TERM_COLOR: always
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Build
       run: cargo build --verbose
 
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Build
       run: cargo build --features handler --verbose
     #- name: Run tests on handler
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Build
       run: cargo build --features extended-handler --verbose
     #- name: Run tests on handler
@@ -42,6 +42,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Rustfmt
       run: 'bash -c "find src/ -name \"*.rs\" | xargs rustfmt --check"'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ async-trait = { version = "0.1", optional = true }
 
 log = { version = "0.4", optional = true }
 
-anymap = {version = "0.12", optional = true}
+anymap = {version = "1.0.0-beta.2", optional = true}
 rustls = {version = "0.20", optional = true }
 [dependencies.serde]
 version = "1"

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -22,7 +22,7 @@ use reqwest::Client;
 use log::{debug, error};
 use std::fmt;
 
-use anymap::{any::CloneAny, Map};
+use anymap::{CloneAny, Map};
 
 use ed25519_dalek::{PUBLIC_KEY_LENGTH, VerifyingKey};
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -24,9 +24,8 @@ SECURITY TESTS
 #[test]
 // Discord interaction verification test OK 1
 fn crypto_verify_test_ok() {
-    let bytes = hex::decode(TEST_PUB_KEY).unwrap().as_slice();
-
-    let pbk = VerifyingKey::try_from(&bytes).expect("Failed to convert public key.");
+    let bytes = hex::decode(TEST_PUB_KEY).expect("Failed to decode public key.");
+    let pbk = VerifyingKey::try_from(bytes.as_slice()).expect("Failed to convert public key.");
 
     let res = verify_discord_message(pbk,
         "c41278a0cf22bf8f3061756063cd7ef548a3df23d0ffc5496209aa0ad4d9593343801bf11e099f41bca1afcac2c70734eebafede3dec7aac1caa5d8fade5af0c",
@@ -48,11 +47,11 @@ fn crypto_verify_test_ok() {
 }
 
 #[test]
-#[should_panic]
+#[should_panic(expected = "Unexpected invalidation of signature")]
 // Discord interacton verification test invalid 1
 fn crypto_verify_test_fail() {
-    let bytes = hex::decode(TEST_PUB_KEY).unwrap().as_slice();
-    let pbk = VerifyingKey::try_from(bytes).expect("Failed to convert public key.");
+    let bytes = hex::decode(TEST_PUB_KEY).expect("Failed to decode public key.");
+    let pbk = VerifyingKey::try_from(bytes.as_slice()).expect("Failed to convert public key.");
 
     let res = verify_discord_message(pbk,
         "69696969696969696696969696969696969696969696969696969696969696969696969696969696969696969696969696969696969696969696969696696969",


### PR DESCRIPTION
Bump `anymap` dependency to address https://github.com/advisories/GHSA-hc92-9h3m-c39j

---

> [!NOTE]
> Given that `anymap` will be [incompatible](https://github.com/chris-morgan/anymap/issues/53) with a [future version of rustc](https://github.com/rust-lang/rust/issues/127323), consider replacing it with a crate that is actually maintained